### PR TITLE
Gbengataylor review

### DIFF
--- a/OpenshiftDeployment.md
+++ b/OpenshiftDeployment.md
@@ -2,8 +2,8 @@
 
 ## Min requirements
 
-1) `oc` Client Version: 4.12.0
-2) Openshift Cluster: 4.12
+1) `oc` Client Version: 4.11.0 and above
+2) Openshift Cluster: 4.11 and above
 
 ## Introduction
 
@@ -25,16 +25,14 @@ graph TD;
 
         ``` 
             git clone  https://github.com/arunhari82/dotnet-eShopOnWeb.git
-            cd <<Repo directory Name>>  
+            cd dotnet-eShopOnWeb.git
         ```    
+   2) set the namespace as env variable
 
-   2) Create a namespace for deploying the eshop application
+            export namespace=<<namespace>> 
+   3) Create a namespace for deploying the eshop application
 
-            oc new-project <<namespace>>
-
-   3) set the namespace as env variable
-
-            export namespace=<<namespace>>        
+            oc new-project $namespace
 
 
 ## 1) SQL Server
@@ -65,7 +63,7 @@ graph TD;
 
                    --- or ---
 
-        oc apply -f openshift/sql-server/Service.yaml   
+        oc apply -f openshift/sql-server/Service.yaml  -n $namespace 
 
 
 

--- a/OpenshiftDeployment.md
+++ b/OpenshiftDeployment.md
@@ -91,13 +91,15 @@ Since we are building this project from repo home directory we need to specify s
 
         oc new-app dotnet:7.0-ubi8~https://github.com/arunhari82/dotnet-eShopOnWeb.git --name public-api --build-env DOTNET_STARTUP_PROJECT=src/PublicApi/PublicApi.csproj -e ASPNETCORE_URLS='http://+:8080' --strategy=source
 
+### Mount the volume 
+
+       oc set volume deployment/public-api --add --name appsettings-vol --mount-path /opt/app-root/app/appsettings.json --configmap-name=appsettings-cm --sub-path=appsettings.json
+       
+       
 ### Wait for the build to complete by watching logs.
 
        oc logs -f bc/public-api
 
-### Mount the volume 
-
-       oc set volume deployment/public-api --add --name appsettings-vol --mount-path /opt/app-root/app/appsettings.json --configmap-name=appsettings-cm --sub-path=appsettings.json
 
 ## Web App. 
 
@@ -105,13 +107,15 @@ Since we are building this project from repo home directory we need to specify s
 
       oc new-app dotnet:7.0-ubi8~https://github.com/arunhari82/dotnet-eShopOnWeb.git --name web-app --build-env DOTNET_STARTUP_PROJECT=src/Web/Web.csproj -e ASPNETCORE_URLS='http://+:8080' --strategy=source
 
+### Mount the volume       
+
+      oc set volume deployment/web-app --add --name appsettings-vol --mount-path /opt/app-root/app/appsettings.json --configmap-name=appsettings-cm --sub-path=appsettings.json
+      
+      
 ### Wait for the build to complete by watching logs.
 
        oc logs -f bc/web-app      
 
-### Mount the volume       
-
-      oc set volume deployment/web-app --add --name appsettings-vol --mount-path /opt/app-root/app/appsettings.json --configmap-name=appsettings-cm --sub-path=appsettings.json
 
 ### Create a route to serve webapp.   
 

--- a/OpenshiftDeployment.md
+++ b/OpenshiftDeployment.md
@@ -25,7 +25,7 @@ graph TD;
 
         ``` 
             git clone  https://github.com/arunhari82/dotnet-eShopOnWeb.git
-            cd dotnet-eShopOnWeb.git
+            cd dotnet-eShopOnWeb
         ```    
    2) set the namespace as env variable
 

--- a/OpenshiftDeployment.md
+++ b/OpenshiftDeployment.md
@@ -73,11 +73,13 @@ graph TD;
 
  ### Create Configmap
 
-        oc create -f openshift/publicApi/configmap.yaml
-
+        # you have to option to modify attributes such as database by updating the openshift/publicApi/assets/appsettings.json file
+        oc create cm  appsettings-cm  --from-file=appsettings.json=openshift/publicApi/assets/appsettings.json
+        
           ------- or --------
 
-        oc create cm  appsettings-cm  --from-file=appsettings.json=openshift/publicApi/assets/appsettings.json
+        oc create -f openshift/publicApi/configmap.yaml
+
 
 ### Import image as image stream
        

--- a/openshift/publicApi/BuildConfig.yaml
+++ b/openshift/publicApi/BuildConfig.yaml
@@ -6,7 +6,6 @@ metadata:
     app.openshift.io/vcs-uri: 'https://github.com/arunhari82/dotnet-eShopOnWeb.git'
     openshift.io/generated-by: OpenShiftWebConsole
   name: public-api
-  namespace: dotnet
   labels:
     app: public-api
     app.kubernetes.io/component: public-api

--- a/openshift/publicApi/Deployment.yaml
+++ b/openshift/publicApi/Deployment.yaml
@@ -15,7 +15,6 @@ metadata:
   uid: bbbcf6ee-3563-43fe-9ce9-40dd17bb432f
   creationTimestamp: '2023-04-26T19:10:04Z'
   generation: 11
-  namespace: dotnet
   labels:
     app: public-api
     app.kubernetes.io/component: public-api

--- a/openshift/publicApi/configmap.yaml
+++ b/openshift/publicApi/configmap.yaml
@@ -2,7 +2,6 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: appsettings-cm
-  namespace: dotnet
 data:
   appsettings.json: |
     {

--- a/openshift/web-app/BuildConfig.yaml
+++ b/openshift/web-app/BuildConfig.yaml
@@ -6,7 +6,6 @@ metadata:
     app.openshift.io/vcs-uri: 'https://github.com/arunhari82/dotnet-eShopOnWeb.git'
     openshift.io/generated-by: OpenShiftWebConsole
   name: web-app
-  namespace: dotnet
   labels:
     app: web-app
     app.kubernetes.io/component: web-app

--- a/openshift/web-app/Deployment.yaml
+++ b/openshift/web-app/Deployment.yaml
@@ -15,7 +15,6 @@ metadata:
   uid: faa3b782-df2d-405a-a58f-67b8485d7c0b
   creationTimestamp: '2023-04-27T14:24:59Z'
   generation: 7
-  namespace: dotnet
   labels:
     app: web-app
     app.kubernetes.io/component: web-app


### PR DESCRIPTION
in addition to the changes, some other comments

**one thing is that we could possibly update**
- you'll see that for the publicAPi and webAPP Crs, I removed the hardcoded namespace. However, there are still references to the namesspace when it comes to the image name and image trigger, particularly in the Deployment CR. I know you don't have instructions on using the cRS to deploy the publicAPI and webapp but what do you think about using kustomize to set the namespace dynamically in case someone wants to? We could even add those as instructions too
-
 **for the dockerfile strategy for WebApi and PublicApi**
- i suggest the dockerfile be changed so that it isn't run as privileged. That way there is no need for a service account. There's not much we can do with the sqlserver since that image is 3rd party but we should model for developers that there is no need to make the app privileged unless it is essential. If there's a way to reference a different dockerfile in the UI (i think there is using oc new app), then name the non-priviledged dockerfile to Dockerfile.openshift. You can explain why the dockerfile.openshift is different in the instructions

great job, thanks